### PR TITLE
Node 8 compatibility fixes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,8 +6,6 @@
 !/bin/**
 !/customizations/**
 !nodemon.json
-!yarn.lock
-!package-lock.json
 
 # Re-ignore these
 **/.DS_STORE

--- a/app/helpers/codify.js
+++ b/app/helpers/codify.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash')
 // Wraps a string in `backticks` so when it's rendered in markdown it will look cool
 //
 // Options:
@@ -7,7 +8,7 @@ module.exports = function(value, options) {
     return value
   }
 
-  const stringify = !!options?.hash?.stringify
+  const stringify = !!get(options, 'hash.stringify')
   if (stringify) {
     value = JSON.stringify(value)
   }

--- a/app/helpers/mdLink.js
+++ b/app/helpers/mdLink.js
@@ -1,8 +1,9 @@
+const { get } = require('lodash')
 const codify = require('./codify')
 
 // Creates a markdown link. The text can be optionally rendered as code
 module.exports = function(text, url, options) {
-  if (options?.hash?.codify === true) {
+  if (get(options, 'hash.codify') === true) {
     text = codify(text)
   }
 

--- a/app/helpers/stripTrailing.js
+++ b/app/helpers/stripTrailing.js
@@ -1,10 +1,11 @@
+const { get } = require('lodash')
 // Strip off a trailer that's found at the end of a string
 module.exports = function(string, trailer, options) {
   if (!(string && trailer)) {
     return string
   }
 
-  if (options?.hash?.isRegex) {
+  if (get(options, 'hash.isRegex')) {
     return string.replace(new RegExp(`${trailer}$`), '')
   } else if (string.endsWith(trailer)) {
     return string.slice(0, trailer.length * -1)

--- a/app/helpers/ternary.js
+++ b/app/helpers/ternary.js
@@ -1,10 +1,11 @@
+const { get } = require('lodash')
 // Implements a simple ternary helper.
 //
 // Options:
 //   undefOnly (Boolean) default = false: If truthy, only values that are undefined will trigger the ifFalse
 //     condition path.
 module.exports = function(value, ifTrue, ifFalse, options) {
-  const undefOnly = !!options?.hash?.undefOnly
+  const undefOnly = !!get(options, 'hash.undefOnly')
 
   if (value) {
     return ifTrue

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -194,7 +194,7 @@ var common = {
           // If the value has a properties.return, then it's a "field" on a Type
           // or an individual "query" or "mutation", and the schema to use for the
           // example is in properties.return
-          if (v.type === 'object' && v.properties?.return) {
+          if (v.type === 'object' && _.get(v, 'properties.return')) {
             v = v.properties.return
           }
           if (showReadOnly || v.readOnly !== true) {

--- a/app/spectaql/augmenters.js
+++ b/app/spectaql/augmenters.js
@@ -60,7 +60,7 @@ function addExamplesFromMetadata (args = {}) {
 }
 
 function addExamplesDynamically (args = {}) {
-  const dynamicExamplesProcessingModule = args?.introspectionOptions?.dynamicExamplesProcessingModule
+  const dynamicExamplesProcessingModule = _.get(args, 'introspectionOptions.dynamicExamplesProcessingModule')
 
   if (!dynamicExamplesProcessingModule) {
     console.warn('\n\n\nNO EXAMPLE PROCESSOR PATH PROVIDED\n\n\n')

--- a/app/spectaql/compose-paths.js
+++ b/app/spectaql/compose-paths.js
@@ -106,7 +106,7 @@ module.exports = function composePaths ({ domains, graphQLSchema, jsonSchema }) 
                     // Get the GraphQLField that represents this Query/Mutation
                     const gqlField = gqlType.getFields()[name] || {}
                     // Get its return type so that we can figure out what fields to put in the example
-                    const returnTypeName = gqlField?.type?.name
+                    const returnTypeName = _.get(gqlField, 'type.name')
                     // Get the properties for that return type. If the return type is not documented, this will
                     // be undefined
                     const returnTypeProperties = _.get(jsonSchema, `definitions.${returnTypeName}.properties`)
@@ -122,7 +122,7 @@ module.exports = function composePaths ({ domains, graphQLSchema, jsonSchema }) 
                     const {
                         examplesByArgName,
                         defaultsByArgName,
-                    } = Object.entries(def?.properties?.arguments?.properties || {}).reduce(
+                    } = Object.entries(_.get(def, 'properties.arguments.properties') || {}).reduce(
                         (acc, [name, { example, default: dfault }]) => {
                             if (typeof example !== 'undefined') {
                                 acc.examplesByArgName[name] = example
@@ -140,7 +140,7 @@ module.exports = function composePaths ({ domains, graphQLSchema, jsonSchema }) 
                         }
                     )
 
-                    if (returnTypeProperties && select?.length) {
+                    if (returnTypeProperties && select && select.length) {
                         // Go through each field in the response type and look for an example to add
                         // to the map
                         select.forEach((fieldName) => {

--- a/app/spectaql/index.js
+++ b/app/spectaql/index.js
@@ -100,8 +100,7 @@ module.exports = function(opts) {
 
   // Find the 1 marked Production. Or take the first one if there are any. Or use
   // the URL provided
-  const urlToParse = servers.find((server) => server.production === true)?.url ||
-    servers[0] ||
+  const urlToParse = (servers.find((server) => server.production === true) || servers[0] || {}).url ||
     introspectionUrl
 
   if (!urlToParse) {

--- a/app/spectaql/type-helpers.js
+++ b/app/spectaql/type-helpers.js
@@ -194,7 +194,7 @@ function getTypeFromIntrospectionResponse ({
   introspectionResponse,
 } = {}) {
   kinds = kind ? [kind] : kinds
-  return name && introspectionResponse?.__schema?.types?.find((type) => type.name === name && kinds.includes(type.kind))
+  return name && _.get(introspectionResponse, '__schema.types', []).find((type) => type.name === name && kinds.includes(type.kind))
 }
 
 function getFieldFromIntrospectionResponseType ({
@@ -220,7 +220,7 @@ function returnTypeExistsForJsonSchemaField({
 }
 
 function getReturnTypeNameFromJsonSchemaFieldDefinition (fieldDefinition = {}) {
-  const returnSchema = fieldDefinition?.properties?.return
+  const returnSchema = _.get(fieldDefinition, 'properties.return')
   return returnSchema && getReturnTypeNameFromJsonSchemaReturnSchema(returnSchema)
 }
 
@@ -239,7 +239,7 @@ function getReturnTypeNameFromJsonSchemaReturnSchema(schema = {}) {
 
 // Provide some basic analysis of a type Field from JSON Schema
 function analayzeJsonSchemaFieldDefinition (fieldDefinition = {}) {
-    const returnSchema = fieldDefinition?.properties?.return
+    const returnSchema = _.get(fieldDefinition, 'properties.return')
     const returnType = getReturnTypeNameFromJsonSchemaReturnSchema(returnSchema)
     return {
         ..._analyzeJsonSchemaDefinition(returnSchema),
@@ -290,7 +290,7 @@ function analyzeTypeSchema (thing) {
     getTypesFrom = thing
 
     // parent should have been added to the current context in the right place
-    if (parent?.required?.includes(name)) {
+    if (_.get(parent, 'required', []).includes(name)) {
        isRequired = true
     }
   }


### PR DESCRIPTION
Since we are not yet babelizing the source to any particular target, the syntax used must be compatible with Node 8, since we say we want to support it. Seems like the "optional chaining" (`foo?.bar`) was the only culprit, and is only supported natively [starting at Node 14](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility).

Tested using `nvm` on version `8.17.0`.

Fixes https://github.com/anvilco/spectaql/issues/6
