### PR TITLE
Better looking showTagSummary mode: fix collapse, link, etc

### DIFF
--- a/app/views/partials/layout/content.hbs
+++ b/app/views/partials/layout/content.hbs
@@ -18,7 +18,6 @@
   {{#if showTagSummary}}
     {{>swagger/tags}}
   {{else}}
-    {{! TODO: remove? }}
     {{>swagger/paths}}
   {{/if}}
 

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -43,22 +43,34 @@
   {{#if (nempty tags) }}
     <h5>Operations</h5>
     {{#each tags}}
-      <section>
-        <a href="#tag-{{htmlId name}}">{{name}}</a>
-        <ul>
-          {{#each operations}}
-            <li>
-              <a href="#operation-{{htmlId path}}-{{htmlId method}}">
-                {{#if summary}}
-                  {{summary}}
-                {{else}}
-                  {{toUpperCase method}} {{path}}
-                {{/if}}
-              </a>
-            </li>
-          {{/each}}
-        </ul>
-      </section>
+      {{#if ../showTagSummary}}
+        <section>
+          <a href="#tag-{{htmlId name}}">{{name}}</a>
+          <ul>
+            {{#each operations}}
+              <li>
+                <a href="#operation-{{htmlId path}}-{{htmlId method}}">
+                  {{#if summary}}
+                    {{summary}}
+                  {{else}}
+                    {{toUpperCase method}} {{path}}
+                  {{/if}}
+                </a>
+              </li>
+            {{/each}}
+          </ul>
+        </section>
+    {{else}}
+      {{#each operations}}
+        <a href="#operation-{{htmlId path}}-{{htmlId method}}">
+          {{#if summary}}
+            {{summary}}
+          {{else}}
+            {{toUpperCase method}} {{path}}
+          {{/if}}
+        </a>
+      {{/each}}
+    {{/if}}
     {{/each}}
   {{/if}}
 

--- a/app/views/partials/swagger/paths.hbs
+++ b/app/views/partials/swagger/paths.hbs
@@ -1,4 +1,3 @@
-{{! TODO: remove? }}
 {{!--
   Original work Copyright (c) 2015 Nils Knappmeier
   https://github.com/bootprint/bootprint-openapi

--- a/examples/data/schema.txt
+++ b/examples/data/schema.txt
@@ -45,9 +45,3 @@ type Query {
 
   myTypes: [MyType]
 }
-
-type Mutation {
-  myMutation(
-    myArg: String
-  ): String
-}


### PR DESCRIPTION
[Now](https://github.com/anvilco/spectaql/pull/9) that `showTagSummary` will no longer trigger errors, we ought to make it look good, too.

1. Removes the "accordion" effect in this case.
2. Puts the `<a>` tags back in the nav so that Traverse works.

![image](https://user-images.githubusercontent.com/2524009/112092404-a82d8000-8b54-11eb-9561-385c210fc2fc.png)