### PR TITLE
Newhouse/issue 11/proper example for query or mutation return type

### DIFF
--- a/app/spectaql/type-helpers.js
+++ b/app/spectaql/type-helpers.js
@@ -13,6 +13,15 @@ const SCALARS = {
     ID: 'string',
 };
 
+
+function digNonNullTypeGraphQL(graphqlType) {
+    while (graphqlType instanceof GraphQLNonNull || graphqlType instanceof GraphQLList) {
+        graphqlType = graphqlType.ofType
+    }
+
+    return graphqlType
+}
+
 // Create a JSON Schema and provide metainfo from a GraphQL instance. This is usually
 // from something parsing the Introspection Query results. Like in fetch-schema.js:
 // const graphQLSchema = graphql.buildClientSchema(introspectionResponse, { assumeValid: true })
@@ -310,6 +319,7 @@ function analyzeTypeSchema (thing) {
 }
 
 module.exports = {
+    digNonNullTypeGraphQL,
     convertGraphQLType,
     convertGraphQLJSONType,
     typeIsRequired,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectaql",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A powerful library for autogenerating static GraphQL API documentation",
   "author": "Anvil Foundry Inc. <hello@useanvil.com>",
   "license": "MIT",


### PR DESCRIPTION
The library was already attempting to respect the "documentedness" (i.e. "hidden or not-ness") of Fields, Types, etc, all over. However, when generating examples for Queries or Mutations whose return types were complex/non-scalar (e.g. `[String]` or `[String!]!'`) then that guarantee / respect was lost.

Simple bugfix, more or less.

Fixes https://github.com/anvilco/spectaql/issues/11