### PR TITLE
Better support for input types + bug fixes

### DIFF
--- a/app/helpers/isInputType.js
+++ b/app/helpers/isInputType.js
@@ -1,0 +1,29 @@
+// Determine if a value is a JSON-schema version of an Input Type.
+// This is not a robust, super-unique check to do, but it's all about where in a
+// schema it's used that makes it work properly
+module.exports = (value) => {
+  // {
+  //   "type": "object",
+  //   "properties": {
+  //     "name": {
+  //       "$ref": "#/definitions/String",
+  //       "type": "string"
+  //     },
+  //     "completed": {
+  //       "$ref": "#/definitions/Boolean",
+  //       "type": "boolean"
+  //     },
+  //     "color": {
+  //       "$ref": "#/definitions/Color",
+  //       "default": "RED"
+  //     },
+  //     "pageSizes" : {
+  //       "type" : "array",
+  //       "items" : {
+  //         "$ref" : "#/definitions/JSON"
+  //       },
+  //     },
+  //   }
+  // }
+  return value && value.type === 'object' && value.properties && Object.values(value.properties).every((schema) => schema.$ref || (schema.type === 'array' && schema.items && schema.items.$ref))
+}

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -179,7 +179,9 @@ var common = {
     // If there's an example, use it.
     if (ref.example !== undefined) {
       return ref.example
-
+    } else if (typeof ref.default !== 'undefined') {
+      // If there is a default, use it.
+      return addSpecialTags(ref.default, { placeholdQuotes: true })
     } else if (ref.$ref) { // && !ref.type
       // Don't expand out nested things...just stick their type in there
       return this.getReferenceName(ref.$ref)

--- a/app/spectaql/augmenters.js
+++ b/app/spectaql/augmenters.js
@@ -432,7 +432,6 @@ function hideFields(args = {}) {
     }) => {
       typeDefinition.properties = Object.entries(typeDefinition.properties).reduce(
         (acc, [fieldName, fieldDefinition]) => {
-
           if (thingTypeToHideIfReturnTypeUndocumentedMap[typeOfThing] &&
             !returnTypeExistsForJsonSchemaField({
               jsonSchema,

--- a/app/spectaql/type-helpers.js
+++ b/app/spectaql/type-helpers.js
@@ -224,7 +224,10 @@ function returnTypeExistsForJsonSchemaField({
   jsonSchema,
   fieldDefinition,
 } = {}) {
-  const returnTypeName = getReturnTypeNameFromJsonSchemaFieldDefinition(fieldDefinition)
+
+  // Fields on proper Types will have properties.return...but (at least) Input Types will have $ref right at the top
+  // or nested in { type: 'array', items: { $ref: '...' } }
+  const returnTypeName = getReturnTypeNameFromJsonSchemaFieldDefinition(fieldDefinition) || getReturnTypeNameFromJsonSchemaReturnSchema(fieldDefinition)
   return !!returnTypeName && _.has(jsonSchema, `definitions.${returnTypeName}`)
 }
 

--- a/app/stylesheets/_schema.scss
+++ b/app/stylesheets/_schema.scss
@@ -272,7 +272,8 @@ a > code {
   @include named-section($msg-json-section-properties);
 }
 
-.json-schema-properties-enum {
+// This one just doesn't have any named-section
+.json-schema-properties-blank {
   @extend .json-schema-properties-base;
 }
 

--- a/app/views/partials/json-schema/enum.hbs
+++ b/app/views/partials/json-schema/enum.hbs
@@ -2,28 +2,28 @@
   <section class="json-schema-description">
     {{md description}}
   </section>
-  {{#if anyOf}}
-    <section class="json-schema-properties-enum">
-      <table>
+{{/if}}
+{{#if anyOf}}
+  <section class="json-schema-properties-blank">
+    <table>
+      <tr>
+        <th>Enum Value</th>
+        <th>Description</th>
+      </tr>
+      {{#each anyOf}}
         <tr>
-          <th>Enum Value</th>
-          <th>Description</th>
+          {{! The Value column }}
+          <td>{{md (codify enum.[0])}}</td>
+          <td>
+            {{! The Description column }}
+            {{#if description}}
+              {{md description}}
+            {{/if}}
+          </td>
         </tr>
-        {{#each anyOf}}
-          <tr>
-            {{! The Value column }}
-            <td>{{md (codify enum.[0])}}</td>
-            <td>
-              {{! The Description column }}
-              {{#if description}}
-                {{md description}}
-              {{/if}}
-            </td>
-          </tr>
-        {{/each}}
-      </table>
-    </section>
-  {{/if}}
+      {{/each}}
+    </table>
+  </section>
 {{/if}}
 
 {{!-- Old way of doing Enum values

--- a/app/views/partials/json-schema/input-type.hbs
+++ b/app/views/partials/json-schema/input-type.hbs
@@ -1,0 +1,29 @@
+{{#if description}}
+  <section class="json-schema-description">
+    {{md description}}
+  </section>
+{{/if}}
+{{#if properties }}
+  <section class="json-schema-properties-blank">
+    <table>
+      <tr>
+        <th>Input Field</th>
+        <th>Description</th>
+      </tr>
+      {{#each properties}}
+        <tr>
+          {{! The Value column }}
+          <td>
+            {{~> graphql/name-and-type name=@key parent=.. }}
+          </td>
+          <td>
+            {{! The Description column }}
+            {{#if description}}
+              {{md description}}
+            {{/if}}
+          </td>
+        </tr>
+      {{/each}}
+    </table>
+  </section>
+{{/if}}

--- a/app/views/partials/json-schema/properties.hbs
+++ b/app/views/partials/json-schema/properties.hbs
@@ -9,10 +9,10 @@
   This does the Fields on Types
 --}}
 {{#if properties}}
-<section class="json-schema-properties">
+<section class="json-schema-properties-blank">
   <table>
     <tr>
-      <th>Name</th>
+      <th>Field Name</th>
       <th>Description</th>
     </tr>
     {{#each properties}}

--- a/app/views/partials/swagger/definition.hbs
+++ b/app/views/partials/swagger/definition.hbs
@@ -34,6 +34,8 @@
       {{else}}
         {{#if (isEnum . )}}
           {{>json-schema/enum}}
+        {{else if (isInputType .)}}
+          {{>json-schema/input-type}}
         {{else}}
           {{>json-schema/body}}
         {{/if}}

--- a/examples/data/schema.txt
+++ b/examples/data/schema.txt
@@ -57,3 +57,11 @@ enum EpisodeEnum {
   "Who are the Ewoks?"
   JEDI
 }
+
+"An Input Type for filtering things"
+input FilterType {
+  "Comment for someField"
+  someField: Boolean = false
+  "Comment for anotherField"
+  anotherField: String
+}


### PR DESCRIPTION
See the issue for more details: https://github.com/anvilco/spectaql/issues/13

- Fixes / adds support for `INPUT_TYPE`.
- Uses the `default` from the schema, if there is one (after looking for `example` first)
- Fixes a few little bugs


Fixes https://github.com/anvilco/spectaql/issues/13

![image](https://user-images.githubusercontent.com/2524009/116329205-ab351500-a77f-11eb-92f7-2559503fda58.png)
