### PR TITLE
Newhouse/issue 50/url errors

### DIFF
--- a/app/spectaql/index.js
+++ b/app/spectaql/index.js
@@ -41,7 +41,7 @@ module.exports = function(opts) {
     },
     domains = [],
     servers = [],
-    info,
+    info = {},
     externalDocs,
     securityDefinitions,
   } = spec
@@ -105,11 +105,13 @@ module.exports = function(opts) {
 
   // Find the 1 marked Production. Or take the first one if there are any. Or use
   // the URL provided
-  const urlToParse = (servers.find((server) => server.production === true) || servers[0] || {}).url ||
-    introspectionUrl
+  const urlToParse =
+    info['x-swaggerUrl']
+    || (servers.find((server) => server.production === true) || servers[0] || {}).url
+    || introspectionUrl
 
   if (!urlToParse) {
-    throw new Error('Must provide Introspection URL')
+    throw new Error('Please provide either: introspection.url OR servers.url OR info.x-swaggerUrl for Swagger spec compliance')
   }
 
   const {

--- a/config-example.yml
+++ b/config-example.yml
@@ -28,6 +28,8 @@ introspection:
   #
 
   # URL of the GraphQL endpoint to hit if you want to generate the documentation based on live Introspection Query results
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
   url: https://yoursite.com/graphql
 
   # File containing a GraphQL Schema Definition written in SDL
@@ -161,6 +163,9 @@ introspection:
   ##############################################
 
 servers:
+  # NOTE: If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement.
+
   # same format as for OpenAPI Specification https://swagger.io/specification/#server-object
 
   - url: https://yoursite.com/graphql
@@ -218,3 +223,7 @@ info:
   # If you really want to hide the "Documentation by" at the bottom of your output, you can do so here
   # Default: false
   x-hidePoweredBy: false
+
+  # If not using introspection.url OR servers[], you need to provide x-swaggerUrl
+  # to satisfy the URL Swagger requirement. This allows for that.
+  x-swaggerUrl: https://yoursite.com/graphql

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectaql",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A powerful library for autogenerating static GraphQL API documentation",
   "author": "Anvil Foundry Inc. <hello@useanvil.com>",
   "license": "MIT",

--- a/test/app/spectaql/index.test.js
+++ b/test/app/spectaql/index.test.js
@@ -1,4 +1,8 @@
 const spectaql = require('app/spectaql')
+const {
+  pathToSimpleSchema,
+} = require('test/helpers')
+
 
 describe('index', function () {
 
@@ -8,6 +12,8 @@ describe('index', function () {
 
   def('specData', () => ({
     introspection: $.introspection,
+    info: $.info,
+    servers: $.servers,
   }))
 
   def('introspection', () => ({
@@ -16,6 +22,52 @@ describe('index', function () {
     introspectionFile: $.introspectionFile,
     metadataFile: $.metadataFile,
   }))
+
+  def('schemaFile', () => pathToSimpleSchema)
+
+  def('info', () => ({
+    ['x-swaggerUrl']: $.swaggerUrl
+  }))
+
+  def('swaggerUrl', () => 'http://foo.com')
+
+  describe('Swagger URL related', function () {
+    it('works baseline', function () {
+      const result = spectaql($.opts)
+      return expect(result).to.be.ok
+    })
+
+    context('no x-swaggerUrl', function () {
+      def('swaggerUrl', () => undefined)
+      it('errors', function () {
+        return expect(() => spectaql($.opts)).to.throw('Please provide either: introspection.url OR servers.url OR info.x-swaggerUrl for Swagger spec compliance')
+      })
+
+      context('there are servers', function () {
+        def('servers', () => ([
+          {
+            url: 'http://foo.com',
+          }
+        ]))
+
+        it("doesn't error", function () {
+          const result = spectaql($.opts)
+          return expect(result).to.be.ok
+        })
+      })
+
+      // TODO: stub this out so that it gets tested
+      context.skip('there is an introspectionUrl (only)', function () {
+        def('schemaFile', () => undefined)
+        def('introspectionUrl', () => 'http://foo.com')
+
+        it("doesn't error", function () {
+          const result = spectaql($.opts)
+          return expect(result).to.be.ok
+        })
+      })
+    })
+  })
 
   context('Introspection Response has errors', function () {
     def('schemaFile', () => './test/fixtures/bad-schema.txt')

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,6 +3,8 @@ const {
   introspectionResponseFromSchema,
 } = require('app/spectaql/graphql-loaders')
 
+const pathToSimpleSchema = './test/fixtures/simple-schema.txt'
+
 const generateIntrospectionQueryResult = ({
   schemaType = 'simple',
 }) => {
@@ -10,7 +12,7 @@ const generateIntrospectionQueryResult = ({
   switch (schemaType) {
     case 'simple':
     default: {
-      const schema = loadSchemaFromSDLFile({ pathToFile: './test/fixtures/simple-schema.txt' })
+      const schema = loadSchemaFromSDLFile({ pathToFile: pathToSimpleSchema })
       return introspectionResponseFromSchema({ schema })
     }
   }
@@ -18,4 +20,5 @@ const generateIntrospectionQueryResult = ({
 
 module.exports = {
   generateIntrospectionQueryResult,
+  pathToSimpleSchema,
 }


### PR DESCRIPTION
One should not have to provide any of the things that are currently required regarding the `urlToParse`. But, because it's swaggerific, I will not just eliminate it completely from being provided, so something satisfactory can be provided even if it's not (probably) going to end up in the UI.

Addresses #50