### PR TITLE
Arbitrary headers support

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -69,7 +69,7 @@ const introspectionOptionDefaults = {
 function resolvePaths (options, keys = ['targetDir', 'appDir', 'logoFile', 'faviconFile', 'specFile']) {
   keys.forEach((key) => {
     const val = options[key]
-    if (val && val.startsWith('.')) {
+    if (typeof val === 'string' && val.startsWith('.')) {
       options[key] = path.resolve(val)
     }
   })
@@ -83,7 +83,9 @@ function resolveOptions(options) {
     schemaFile: 'schemaFile',
     introspectionFile: 'introspectionFile',
     introspectionMetadataFile: 'metadataFile',
-    dynamicExamplesProcessingModule : 'dynamicExamplesProcessingModule',
+    dynamicExamplesProcessingModule: 'dynamicExamplesProcessingModule',
+    header: 'authHeader',
+    headers: 'headers',
   }
 
   // Resolve the top-level paths

--- a/app/spectaql/graphql-loaders.js
+++ b/app/spectaql/graphql-loaders.js
@@ -1,3 +1,5 @@
+const isEmpty = require('lodash/isEmpty')
+
 const {
   buildClientSchema,
   buildSchema,
@@ -43,18 +45,21 @@ const loadIntrospectionResponseFromFile = ({
   return standardizeIntrospectionQueryResult(fileToObject(pathToFile))
 }
 
-const loadIntrospectionResponseFromUrl = ({ authHeader, url }) => {
+const loadIntrospectionResponseFromUrl = ({ headers, url }) => {
   const requestBody = {
     operationName: "IntrospectionQuery",
     query: getIntrospectionQuery()
   };
 
-  const responseBody = request("POST", url, {
-    headers: {
-      authorization: authHeader,
-    },
+  const requestOpts = {
     json: requestBody
-  }).getBody('utf8')
+  }
+
+  if (!isEmpty(headers)) {
+    requestOpts.headers = headers
+  }
+
+  const responseBody = request("POST", url, requestOpts).getBody('utf8')
 
   // Standardize it
   return standardizeIntrospectionQueryResult(

--- a/app/spectaql/index.js
+++ b/app/spectaql/index.js
@@ -28,7 +28,6 @@ function errorThingDone ({ trying, done }) {
 module.exports = function(opts) {
   const {
     specData: spec,
-    authHeader,
   } = opts
 
   const {
@@ -38,6 +37,8 @@ module.exports = function(opts) {
       schemaFile,
       introspectionFile,
       metadataFile,
+      authHeader,
+      headers,
     },
     domains = [],
     servers = [],
@@ -68,7 +69,18 @@ module.exports = function(opts) {
       errorThingDone({ trying: 'load Introspection from URL', done })
     }
 
-    introspectionResponse = loadIntrospectionResponseFromUrl({ authHeader, url: introspectionUrl })
+    if (authHeader && headers) {
+      throw new Error('Cannot provide both header and headers options. Please choose one.')
+    }
+    let resolvedHeaders = {}
+    if (authHeader) {
+      resolvedHeaders.authorization = authHeader
+    } else if (headers) {
+      // CLI headers come in as a string; YAML as an object.
+      resolvedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers
+    }
+
+    introspectionResponse = loadIntrospectionResponseFromUrl({ headers: resolvedHeaders, url: introspectionUrl })
     done = 'loaded via Introspection URL'
   }
 

--- a/bin/spectaql.js
+++ b/bin/spectaql.js
@@ -50,7 +50,9 @@ program.version(package.version)
   .option('--dynamic-examples-processing-module <file>', 'specify a JS module that will dynamically generate schema examples (default: /customizations/examples', String)
 
   .option('-g, --grunt-config-file <file>', 'specify a custom Grunt configuration file (default: app/lib/gruntConfig.js)', String)
+  // TODO: remove this option in favor of --headers as part of a breaking change
   .option('-H, --header <header>', 'specify a custom auth token for the header (default: none)')
+  .option('-A, --headers <headers>', 'specify arbitrary headers for the Introspection Query as a JSON string (default: none)', String)
   .option('-q, --quiet', 'Silence the output from the generator (default: false)')
   // .option('-f, --spec-file <file>', 'the input OpenAPI/Swagger spec file (default: test/fixtures/petstore.json)', String, 'test/fixtures/petstore.json')
   .parse(process.argv)

--- a/config-example.yml
+++ b/config-example.yml
@@ -40,6 +40,11 @@ introspection:
   #
   ##############################################
 
+  # If using the "url" option above, any headers (such as Authorization) can be added here. This
+  # can also be added via the CLI options
+  headers:
+    Authorization: Bearer s3cretT0k2n
+
   ##############################################
   # These options specify how, where and if any "metadata" information is to be added to your Introspection
   # Query results IF it is not already present. If you are not dealing with metadata, or you have already

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectaql",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A powerful library for autogenerating static GraphQL API documentation",
   "author": "Anvil Foundry Inc. <hello@useanvil.com>",
   "license": "MIT",


### PR DESCRIPTION
Support arbitrary request headers in the CLI or YAML.

Closes https://github.com/anvilco/spectaql/issues/49