### PR TITLE
[1-min] union support is now baked into graphql-2-json-schema

### DIFF
--- a/app/helpers/isUnionType.js
+++ b/app/helpers/isUnionType.js
@@ -1,4 +1,4 @@
 // Determine if a value is a JSON-schema version of a Unioin
 module.exports = (value) => {
-  return value && typeof value.type === 'undefined' && Array.isArray(value.anyOf) && value.anyOf.length && value.anyOf.every((schema) => !!schema.$ref)
+  return !!value && typeof value.type === 'undefined' && Array.isArray(value.oneOf) && value.oneOf.length && value.oneOf.every((schema) => !!schema.$ref)
 }

--- a/app/spectaql/augmenters.js
+++ b/app/spectaql/augmenters.js
@@ -24,7 +24,6 @@ const calculateShouldDocument = ({ undocumented, documented, def }) => {
 }
 
 function augmentData (args) {
-  _temporaryAddUnionTypes(args)
   hideThingsBasedOnMetadata(args)
   addExamplesFromMetadata(args)
   addExamplesDynamically(args)
@@ -617,37 +616,6 @@ function addDeprecationThings (args = {}) {
   })
 }
 
-// This should go away if/when graphql-2-json-schema update for Union support gets in
-function _temporaryAddUnionTypes (args = {}) {
-  const {
-    introspectionResponse,
-    jsonSchema,
-  } = args
-
-  const unionTypes = _.get(introspectionResponse, '__schema.types', []).filter(
-    (type) => type.kind === 'UNION'
-  )
-
-  if (!unionTypes.length) {
-    return
-  }
-
-  unionTypes.forEach((type) => {
-    const { name, description, possibleTypes } = type
-    const  definition = {
-      anyOf: possibleTypes.map(({ name }) => ({ $ref: `#/definitions/${name}`})),
-    }
-
-    if (typeof description !== 'undefined') {
-      definition.description = description
-    }
-
-    jsonSchema.definitions[name] = definition
-  })
-
-  return args
-}
-
 // Just a helper function to standardize some looping/processing that will happen
 // a few times, but slightly different
 function _goThroughThings ({
@@ -701,7 +669,6 @@ function _goThroughThings ({
 }
 
 module.exports = {
-  _temporaryAddUnionTypes,
   hideThingsBasedOnMetadata,
   addExamplesFromMetadata,
   addExamplesDynamically,

--- a/app/views/partials/json-schema/union-type.hbs
+++ b/app/views/partials/json-schema/union-type.hbs
@@ -3,13 +3,13 @@
     {{md description}}
   </section>
 {{/if}}
-{{#if anyOf}}
+{{#if oneOf}}
   <section class="json-schema-properties-blank">
     <table>
       <tr>
         <th>Union Types</th>
       </tr>
-      {{#each anyOf}}
+      {{#each oneOf}}
         <tr>
           {{! The Union Types column }}
           <td>{{md (mdTypeLink . codify=true) addClass=(ternary (and isDeprecated (not @root.info.x-hideIsDeprecated)) "swagger-operation-deprecated" false)}}</td>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "commander": "^7.2.0",
     "foundation-sites": "^6.6.3",
     "graphql": "^14.1.1",
-    "graphql-2-json-schema": "0.6.0",
+    "graphql-2-json-schema": "0.7.0",
     "graphql-json-schema": "^0.1.2",
     "grunt": "^1.4.1",
     "grunt-compile-handlebars": "^2.0.2",

--- a/test/app/helpers/isUnion.test.js
+++ b/test/app/helpers/isUnion.test.js
@@ -1,0 +1,37 @@
+const isUnionType = require('../../../app/helpers/isUnionType')
+
+describe('isUnionType', function () {
+  it('works', function () {
+
+    const validUnion = {
+      desription: 'A valid Union',
+      oneOf: [
+        { $ref: 'a/type-a' },
+        { $ref: 'a/type-b' }
+      ]
+    }
+
+    const hasType = {
+      desription: 'Why do I have a type?',
+      type: 'object',
+      oneOf: [
+        { $ref: 'a/type-a' },
+        { $ref: 'a/type-b' }
+      ]
+    }
+
+    const missingRef = {
+      desription: 'Why am I missing a ref?',
+      oneOf: [
+        { $ref: 'a/type-a' },
+        { foo: 'bar' },
+      ]
+    }
+
+    expect(isUnionType(validUnion)).to.be.true
+
+    expect(isUnionType(hasType)).to.be.false
+    expect(isUnionType(missingRef)).to.be.false
+    expect(isUnionType(null)).to.be.false
+  })
+})

--- a/test/app/spectaql/augmenters.test.js
+++ b/test/app/spectaql/augmenters.test.js
@@ -14,7 +14,6 @@ const {
 } = require('app/lib/common')
 
 const {
-  _temporaryAddUnionTypes,
   hideThingsBasedOnMetadata,
   addExamplesFromMetadata,
   addExamplesDynamically,
@@ -829,30 +828,6 @@ describe('augmenters', function () {
           expect(jsonSchema[area][typeName].properties[fieldName].properties.arguments.properties).to.eql({})
         })
       })
-    })
-  })
-
-  describe('_temporaryAddUnionTypes', function () {
-    def('result', () => _temporaryAddUnionTypes({
-      introspectionResponse: $.introspectionResponse,
-      jsonSchema: $.jsonSchema,
-      graphQLSchema: $.graphQLSchema,
-      introspectionOptions: $.introspectionOptions,
-    }))
-
-    it('mixes in Union types', function () {
-      const jsonSchemaBefore = _.cloneDeep($.jsonSchema)
-      const { jsonSchema } = $.result
-      expect(jsonSchemaBefore).to.not.eql(jsonSchema)
-      expect(jsonSchema.definitions).to.be.an('object').that.has.any.keys('CombinedTypes')
-      const combinedTypes = jsonSchema.definitions.CombinedTypes
-      expect(combinedTypes).to.be.ok
-      expect(combinedTypes.description).to.eql('Some combined types')
-      expect(combinedTypes.anyOf).to.be.an('array').of.length(2)
-      expect(combinedTypes.anyOf).to.eql([
-        { $ref: '#/definitions/MyType'},
-        { $ref: '#/definitions/OtherType'},
-      ])
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,10 +1839,10 @@ graphlib@^2.1.8:
   dependencies:
     lodash "^4.17.15"
 
-graphql-2-json-schema@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/graphql-2-json-schema/-/graphql-2-json-schema-0.6.0.tgz"
-  integrity sha512-YsEpASUFmnDff/9wtePDHFMqLkNXm9ghTeUFtHgwzpH9E/0qD5lsQ6RKs1O9JsiwjTXkM+4gPokiIxGpzc9Ryw==
+graphql-2-json-schema@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/graphql-2-json-schema/-/graphql-2-json-schema-0.7.0.tgz#538cd78bc7fcec456f8c8c77c5fef0b38a0b7cb0"
+  integrity sha512-lmZAmF9FliOx/FdrWOvqV2+lzHI4l/Pjsm6xdzZ6ZYkQYEARzdrw6YglMf9WEI8fDE1ciwPloM/H6jyuy1CyRQ==
   dependencies:
     lodash "^4.17.20"
 


### PR DESCRIPTION
Sorta updates the changes done [here](https://github.com/anvilco/spectaql/pull/75) to use the built-in support added [here](https://github.com/charlypoly/graphql-to-json-schema/pull/36).