### PR TITLE
Support INPUT_OBJECT metadata examples

### DIFF
--- a/examples/data/metadata.json
+++ b/examples/data/metadata.json
@@ -26,5 +26,23 @@
     "DateTime": {
       "documentation": { "example": "\"2016-10-07T01:08:03.420Z\"" }
     }
+  },
+  "INPUT_OBJECT": {
+    "FilterType": {
+      "inputFields": {
+        "someField": {
+          "documentation": { "example": true }
+        },
+        "anotherField": {
+          "documentation": { "example": "Metadata example of `anotherField`" }
+        },
+        "lastName": {
+          "documentation": { "example": "Doe" }
+        },
+        "episodeEnums": {
+          "documentation": { "example": ["EMPIRE"] }
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/anvilco/spectaql",
   "dependencies": {
-    "@anvilco/apollo-server-plugin-introspection-metadata": "^1.1.0",
+    "@anvilco/apollo-server-plugin-introspection-metadata": "^1.1.1",
     "@anvilco/graphql-2-json-schema": "^0.0.2",
     "@graphql-tools/load-files": "^6.3.2",
     "@graphql-tools/merge": "^6.2.14",

--- a/test/app/spectaql/augmenters.test.js
+++ b/test/app/spectaql/augmenters.test.js
@@ -59,7 +59,13 @@ describe('augmenters', function () {
       ): String
 
       myOtherMutation: MyType
-    }`
+    }
+
+    input MyInput {
+      inputOne: String
+      inputTwo: Int
+    }
+  `
   )
   def('schemaSDL', () => $.schemaSDLBase)
 
@@ -77,6 +83,11 @@ describe('augmenters', function () {
       Mutation: {
 
       }
+    },
+    'INPUT_OBJECT': {
+      MyInput: {
+
+      },
     }
   }))
   def('metadata', () => $.metadataBase)
@@ -604,6 +615,20 @@ describe('augmenters', function () {
             }
           }
         }
+      },
+      'INPUT_OBJECT': {
+        MyInput: {
+          // Should have no impact, example-wise
+          metadata: $.theMetadata,
+          inputFields: {
+            inputOne: {
+              metadata: $.theMetadata,
+            },
+            inputTwo: {
+              metadata: $.theMetadata,
+            },
+          },
+        },
       }
     }))
 
@@ -633,11 +658,14 @@ describe('augmenters', function () {
 
         // No top-level example
         expect(jsonSchema.definitions.MyType).be.an('object').that.does.not.have.any.keys('example')
+        expect(jsonSchema.definitions.MyInput).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Query).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Mutation).be.an('object').that.does.not.have.any.keys('example')
 
         // Type Fields have example...
         expect(jsonSchema.definitions.MyType.properties.myField.properties.return.example).to.eql($.processedExample)
+        // Input Fields have example...
+        expect(jsonSchema.definitions.MyInput.properties.inputOne.example).to.eql($.processedExample)
         // ...queries and mutations DO NOT
         expect(jsonSchema.properties.Query.properties.myQuery).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Mutation.properties.myMutation).be.an('object').that.does.not.have.any.keys('example')
@@ -664,11 +692,14 @@ describe('augmenters', function () {
 
           // No top-level example
           expect(jsonSchema.definitions.MyType).be.an('object').that.does.not.have.any.keys('example')
+          expect(jsonSchema.definitions.MyInput).be.an('object').that.does.not.have.any.keys('example')
           expect(jsonSchema.properties.Query).be.an('object').that.does.not.have.any.keys('example')
           expect(jsonSchema.properties.Mutation).be.an('object').that.does.not.have.any.keys('example')
 
           // Type Fields have example...
           expect(jsonSchema.definitions.MyType.properties.myField.properties.return.example).to.eql($.processedExample)
+          // Input Fields have example...
+          expect(jsonSchema.definitions.MyInput.properties.inputOne.example).to.eql($.processedExample)
           // ...queries and mutations DO NOT
           expect(jsonSchema.properties.Query.properties.myQuery).be.an('object').that.does.not.have.any.keys('example')
           expect(jsonSchema.properties.Mutation.properties.myMutation).be.an('object').that.does.not.have.any.keys('example')
@@ -694,11 +725,14 @@ describe('augmenters', function () {
 
         // No top-level example
         expect(jsonSchema.definitions.MyType).be.an('object').that.does.not.have.any.keys('example')
+        expect(jsonSchema.definitions.MyInput).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Query).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Mutation).be.an('object').that.does.not.have.any.keys('example')
 
         // Type Fields have example...
         expect(jsonSchema.definitions.MyType.properties.myField.properties.return.example).to.eql($.processedExample)
+        // Input Fields have example...
+        expect(jsonSchema.definitions.MyInput.properties.inputOne.example).to.eql($.processedExample)
         // ...queries and mutations DO NOT
         expect(jsonSchema.properties.Query.properties.myQuery).be.an('object').that.does.not.have.any.keys('example')
         expect(jsonSchema.properties.Mutation.properties.myMutation).be.an('object').that.does.not.have.any.keys('example')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@anvilco/apollo-server-plugin-introspection-metadata@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@anvilco/apollo-server-plugin-introspection-metadata/-/apollo-server-plugin-introspection-metadata-1.1.0.tgz"
-  integrity sha512-q7o/kZ4MIhHj0K5ZhBRJ1h8eGpe3dukL1u2pQlNUEAV31HojaNMOh4ZSH/U/yxpRqyz6J6F/V4dc5wOyQX0qTg==
+"@anvilco/apollo-server-plugin-introspection-metadata@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@anvilco/apollo-server-plugin-introspection-metadata/-/apollo-server-plugin-introspection-metadata-1.1.1.tgz#f4b3d0c817e9cc25125973e6ba55a51d37e73f10"
+  integrity sha512-GhcaXjBYsf61n3cCQiO9sJXGmfVxvh1GD1xWsDPiN8TUo0UKJK2E6XbTXlUq5hFKWpZAa71e8dRwsyrAsG3vxw==
   dependencies:
     lodash.get "^4.4.2"
     lodash.set "^4.3.2"


### PR DESCRIPTION
Our `apollo-server-plugin-introspection-metadata` needed to [be fixed](https://github.com/anvilco/apollo-server-plugin-introspection-metadata/pull/2) to support this...then there were some changes to be made here in SpectaQL after updating the package.

Fixes https://github.com/anvilco/spectaql/issues/84

![image](https://user-images.githubusercontent.com/2524009/133691008-7a1d3794-5dc2-46e4-8f0f-07546a253a68.png)
