### PR TITLE
Allow for additional JS file to be added to JS bundle

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -79,9 +79,10 @@ const introspectionOptionsMap = {
   headers: 'headers',
 }
 
-function resolvePaths (options, keys = ['targetDir', 'appDir', 'logoFile', 'faviconFile', 'specFile']) {
+function resolvePaths (options, keys = ['targetDir', 'appDir', 'logoFile', 'additionalJsFile', 'faviconFile', 'specFile']) {
   keys.forEach((key) => {
     const val = options[key]
+    // TODO: make this "!val.startsWith('/')"?
     if (typeof val === 'string' && val.startsWith('.')) {
       options[key] = path.resolve(val)
     }

--- a/app/lib/gruntConfig.js
+++ b/app/lib/gruntConfig.js
@@ -7,6 +7,13 @@ const node_modules_dependency = path.resolve(root, '..')
 
 
 module.exports = function(grunt, options, spec) {
+  // The basic JS paths
+  const jsSrcPaths = [options.appDir + '/javascripts/**/*.js', '!' + options.appDir + '/javascripts/jquery*.js']
+  // Add in the additional path if needed
+  if (options.additionalJsFile) {
+    jsSrcPaths.push(options.additionalJsFile)
+  }
+
   return {
     // Compile SCSS source files into the cache directory
     sass: {
@@ -40,7 +47,7 @@ module.exports = function(grunt, options, spec) {
     // Concatenate files into 1
     concat: {
       js: {
-        src: [options.appDir + '/javascripts/**/*.js', '!' + options.appDir + '/javascripts/jquery*.js'],
+        src: jsSrcPaths,
         dest: options.cacheDir + '/javascripts/spectaql.js',
       },
       css: {

--- a/bin/spectaql.js
+++ b/bin/spectaql.js
@@ -50,6 +50,10 @@ program.version(package.version)
   .option('--introspection-metadata-file <file>', 'specify a file that contains metadata to be added to the Introspection Query response (default: none)', String)
   .option('--dynamic-examples-processing-module <file>', 'specify a JS module that will dynamically generate schema examples (default: /customizations/examples', String)
 
+  // Optional path to a JS file that will be bundled into the spectaql.min.js with all the other
+  // required JS. Can be useful for setting some values, such as for the Traverse.defaults object
+  .option('--additional-js-file <file>', 'specify a file that contains additional JavaScript to add to the spectaql.min.js', String)
+
   .option('-g, --grunt-config-file <file>', 'specify a custom Grunt configuration file (default: app/lib/gruntConfig.js)', String)
   // TODO: remove this option in favor of --headers as part of a breaking change
   .option('-H, --header <header>', 'specify a custom auth token for the header (default: none)')

--- a/config-example.yml
+++ b/config-example.yml
@@ -6,6 +6,9 @@ spectaql:
   logoFile: path/to/logo.png
   # Optional path to an image to use as a favicon for the site when it's not embedded
   faviconFile: path/to/favicon.png
+  # Optional path to a JS file that will be bundled into the spectaql.min.js with all the other
+  # required JS. Can be useful for setting some values, such as for the Traverse.defaults object
+  additionalJsFile: path/to/additional.js
 
   # Optional string specifying how to build and include CSS for the output:
   #   full: will include a very opinionated set of CSS to make the output look good

--- a/test/app/index.test.js
+++ b/test/app/index.test.js
@@ -60,7 +60,8 @@ describe('index', function () {
       def('config', () => ({
         spectaql: {
           oneFile: true,
-          cssBuildMode: 'basic'
+          cssBuildMode: 'basic',
+          additionalJsFile: './foo.js',
         }
       }))
 
@@ -69,7 +70,8 @@ describe('index', function () {
         const options = resolveOptions($.options)
 
         expect(options.oneFile).to.be.true
-        expect(options.cssBuildMode).to.be.eql('basic')
+        expect(options.cssBuildMode).to.eql('basic')
+        expect(options.additionalJsFile.endsWith('foo.js')).to.be.true
       })
 
       context('CLI specifies some options', function () {
@@ -77,6 +79,7 @@ describe('index', function () {
           ...$._options,
           oneFile: false,
           cssBuildMode: 'ridiculous',
+          additionalJsFile: 'bar.js'
         }))
 
 
@@ -86,6 +89,7 @@ describe('index', function () {
 
           expect(options.oneFile).to.be.false
           expect(options.cssBuildMode).to.be.eql('ridiculous')
+          expect(options.additionalJsFile.endsWith('bar.js')).to.be.true
         })
       })
     })


### PR DESCRIPTION
Allow for an additional JS file to be added to the JS `spectaql.min.js` bundle. 

Will address https://github.com/anvilco/spectaql/issues/160