### PR TITLE
Fix scroll spy + behavior at end

### DIFF
--- a/src/themes/default/javascripts/scroll-spy.js
+++ b/src/themes/default/javascripts/scroll-spy.js
@@ -27,6 +27,17 @@ function scrollSpy() {
     })
   }
 
+  function isElementInViewport(el) {
+    var rect = el.getBoundingClientRect()
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    )
+  }
+
   var handleResize = debounce(function () {
     findScrollPositions()
     handleScroll()
@@ -69,8 +80,8 @@ function scrollSpy() {
       nextEl.classList.add(ACTIVE_CLASS)
       if (nextEl.scrollIntoViewIfNeeded) {
         nextEl.scrollIntoViewIfNeeded()
-      } else if (nextEl.scrollIntoView) {
-        nextEl.scrollIntoView({ behavior: 'smooth' })
+      } else if (nextEl.scrollIntoView && !isElementInViewport(nextEl)) {
+        nextEl.scrollIntoView({ block: 'center', inline: 'start' })
       }
     }
 

--- a/src/themes/default/javascripts/scroll-spy.js
+++ b/src/themes/default/javascripts/scroll-spy.js
@@ -28,6 +28,7 @@ function scrollSpy() {
   }
 
   function isElementInViewport(el) {
+    // https://stackoverflow.com/a/7557433/347554
     var rect = el.getBoundingClientRect()
     return (
       rect.top >= 0 &&

--- a/src/themes/default/stylesheets/main.scss
+++ b/src/themes/default/stylesheets/main.scss
@@ -156,29 +156,6 @@ $background-arguments: #fafbfc;
     }
   }
 
-  #sidebar {
-    a {
-      color: $text-color;
-    }
-
-    a.nav-scroll-active,
-    a:hover {
-      font-weight: bold;
-    }
-
-    a.nav-scroll-active {
-      color: $text-color;
-    }
-
-    a:hover {
-      color: $link-color-hover;
-    }
-
-    @media (min-width: $size-sidebar-break) {
-      border-right: $border-size-thick solid $border-color;
-    }
-  }
-
   #sidebar,
   #docs,
   #mobile-navbar {
@@ -207,6 +184,33 @@ $background-arguments: #fafbfc;
     @media (min-width: $size-content-break) {
       padding-left: $container-padding-desktop;
       padding-right: $container-padding-desktop;
+    }
+  }
+
+  #sidebar {
+    // When there is bottom padding, there is a weird scroll behavior when
+    // scrolling the main panel to the very bottom
+    padding-bottom: 0;
+
+    a {
+      color: $text-color;
+    }
+
+    a.nav-scroll-active,
+    a:hover {
+      font-weight: bold;
+    }
+
+    a.nav-scroll-active {
+      color: $text-color;
+    }
+
+    a:hover {
+      color: $link-color-hover;
+    }
+
+    @media (min-width: $size-sidebar-break) {
+      border-right: $border-size-thick solid $border-color;
     }
   }
 

--- a/src/themes/spectaql/stylesheets/main.scss
+++ b/src/themes/spectaql/stylesheets/main.scss
@@ -216,7 +216,22 @@ $background-sidebar: $background-subtle;
     }
   }
 
+  #docs,
+  #sidebar,
+  #mobile-navbar {
+    @include containerPaddingVertical();
+  }
+
+  #nav,
+  #mobile-navbar,
+  .sidebar-top-container {
+    @include containerPaddingHorizontal();
+  }
+
   #sidebar {
+    // When there is bottom padding, there is a weird scroll behavior when
+    // scrolling the main panel to the very bottom
+    padding-bottom: 0;
     background: $background-sidebar;
 
     a {
@@ -234,18 +249,6 @@ $background-sidebar: $background-subtle;
     @media (min-width: $size-sidebar-break) {
       border-right: $border-size solid $border-color;
     }
-  }
-
-  #docs,
-  #sidebar,
-  #mobile-navbar {
-    @include containerPaddingVertical();
-  }
-
-  #nav,
-  #mobile-navbar,
-  .sidebar-top-container {
-    @include containerPaddingHorizontal();
   }
 
   #logo {


### PR DESCRIPTION
This will make the scroll-spy behave the same in firefox, chrome, etc. That is:

* Don't scroll unless the active item is out of view
* Scroll the sidebar to the center 

Additionally, this fixes a sidebar issue when you scroll the main panel all the way to the bottom.

![scroll-in-center](https://user-images.githubusercontent.com/69169/163077006-0a37a636-73b7-42e6-b7fe-2d7dc50c53ae.gif)

![scroll-to-end](https://user-images.githubusercontent.com/69169/163076999-7999d032-c1a9-4b37-b21c-8dab23d099a7.gif)

Closes #298