### PR TITLE
Limit Scroll Spy to Navigation Elements

### DIFF
--- a/src/themes/default/javascripts/scroll-spy.js
+++ b/src/themes/default/javascripts/scroll-spy.js
@@ -63,7 +63,7 @@ function scrollSpy() {
 
     var activeEl = document.querySelector(`.${ACTIVE_CLASS}`)
     var nextEl = section
-      ? document.querySelector('a[href*=' + section.id + ']')
+      ? document.querySelector('#nav a[href*=' + section.id + ']')
       : null
 
     var parentNextEl = getParentSection(nextEl)


### PR DESCRIPTION
It is currently possible to hide elements in the navigation (`hideInNav`) and/or the content section (`hideInContent`). In case a type is hidden in the navigation but visible in the content, the scroll spy selects the link in the content as target. This leads to "jumps". The PR resolves this by limiting the scroll spy targets to the `#nav` element.