### PR TITLE
apply scroll padding top to html

### DIFF
--- a/src/themes/default/stylesheets/base.scss
+++ b/src/themes/default/stylesheets/base.scss
@@ -8,7 +8,7 @@ $sidebar-top: 0px !default;
 $sidebar-padding: $content-padding !default;
 $sidebar-background: #fff !default;
 
-$overlay-background: rgba(0, 0, 0, .5) !default;
+$overlay-background: rgba(0, 0, 0, 0.5) !default;
 $overlay-background-hidden: rgba(0, 0, 0, 0) !default;
 
 $code-background: #ccc !default;
@@ -26,6 +26,10 @@ $size-content-break: $size-desktop !default;
 // In case there is a navbar. getScrollOffset if a function defined in the grunt
 // config file
 $scroll-offset: getScrollOffset() !default;
+
+html {
+  scroll-padding-top: $scroll-offset;
+}
 
 #spectaql {
   padding: 0;
@@ -98,7 +102,7 @@ $scroll-offset: getScrollOffset() !default;
     min-width: $drawer-size;
     max-width: $drawer-size;
     flex-shrink: 0;
-    transition: transform .2s ease-out;
+    transition: transform 0.2s ease-out;
     transform: translateX(-100%);
     z-index: 10;
 
@@ -148,7 +152,7 @@ $scroll-offset: getScrollOffset() !default;
 
       &::after {
         display: block;
-        content: "";
+        content: '';
         height: 2px;
         background: black;
         box-shadow: 0 5px 0 black, 0 10px 0 black;


### PR DESCRIPTION
I have a CSS formatter that applied some things - let me know if you want me to change it back.

Super simple, applies the scroll offset to the html element so it applies the padding-top to all scroll actions (e.g. click). There are some hacks to make it apply to `body` or other elements, but it's recommended to use `html`:

https://webplatform.news/issues/2019-03-19#the-css-scroll-padding-property-adjusts-a-scroll-container-s-optimal-viewing-region
https://stackoverflow.com/a/60470570/5238640
https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/ - see note @ bottom