### PR TITLE
load main.css before other css files to preserve import behavior

### DIFF
--- a/src/lib/gruntConfig.js
+++ b/src/lib/gruntConfig.js
@@ -31,7 +31,10 @@ module.exports = function (grunt, options, spec) {
         dest: options.cacheDir + '/javascripts/spectaql.js',
       },
       css: {
-        src: [options.cacheDir + '/stylesheets/**/*.css'],
+        src: [
+          options.cacheDir + '/stylesheets/main.css',
+          options.cacheDir + '/stylesheets/**/*.css',
+        ],
         dest: options.cacheDir + '/stylesheets/spectaql.css',
       },
     },


### PR DESCRIPTION
Fixes https://github.com/anvilco/spectaql/issues/352
