### PR TITLE
Add `custom.scss` file to default theme

### DIFF
--- a/examples/themes/README.md
+++ b/examples/themes/README.md
@@ -39,7 +39,8 @@ You can also replace/overwrite any of SpectaQL's default javascript files.
 ### `stylesheets`
 
 Any `.css` files that you add to this folder will be concatenated and minified into the `spectaql.min.css` file of your build's target directory along with the default CSS.
-SpectaQL supports SCSS, and the default CSS is built by processing the `main.scss` in the default theme's `stylesheets/` directory. If your theme provides a `main.scss` file, that will overwrite the default one and be used to direct the SCSS -> CSS build. You can also then include other `.scss` files that can be imported by your `main.scss` file.
+SpectaQL supports SCSS, and the default CSS is built by processing the `main.scss` in the default theme's `stylesheets/` directory. If your theme provides a `main.scss` file, that will overwrite the default one and be used to direct the SCSS -> CSS build. You can also then include other `.scss` files that can be imported by your `main.scss` file. Additionally, there is a `custom.scss` included in the default theme that will be imported by its
+`main.scss` file, but it will not contain any SCSS. You might consider overriding just this file in your custom theme in order to take advantage of any SCSS updates to this library as you update it.
 
 ### `views`
 

--- a/examples/themes/README.md
+++ b/examples/themes/README.md
@@ -40,7 +40,7 @@ You can also replace/overwrite any of SpectaQL's default javascript files.
 
 Any `.css` files that you add to this folder will be concatenated and minified into the `spectaql.min.css` file of your build's target directory along with the default CSS.
 SpectaQL supports SCSS, and the default CSS is built by processing the `main.scss` in the default theme's `stylesheets/` directory. If your theme provides a `main.scss` file, that will overwrite the default one and be used to direct the SCSS -> CSS build. You can also then include other `.scss` files that can be imported by your `main.scss` file. Additionally, there is a `custom.scss` included in the default theme that will be imported by its
-`main.scss` file, but it will not contain any SCSS. You might consider overriding just this file in your custom theme in order to take advantage of any SCSS updates to this library as you update it.
+`main.scss` file, but it will not contain any SCSS. You might consider overriding just this file in your custom theme (instead of the `main.scss` file) in order to take advantage of any SCSS updates to this library as you update it.
 
 ### `views`
 

--- a/src/themes/basic/stylesheets/main.scss
+++ b/src/themes/basic/stylesheets/main.scss
@@ -1,1 +1,2 @@
+@import 'custom';
 @import 'base';

--- a/src/themes/default/stylesheets/custom.scss
+++ b/src/themes/default/stylesheets/custom.scss
@@ -1,0 +1,3 @@
+// This theme will put nothing in here, but it will be imported
+// in "main.scss", allowing users to customize their SCSS without
+// losing updates to the "core" SCSS

--- a/src/themes/default/stylesheets/main.scss
+++ b/src/themes/default/stylesheets/main.scss
@@ -67,6 +67,7 @@ $background-arguments: #fafbfc;
 // Imports
 //////////////////////
 
+@import 'custom';
 @import 'base';
 @import 'monokai';
 

--- a/src/themes/spectaql/stylesheets/main.scss
+++ b/src/themes/spectaql/stylesheets/main.scss
@@ -78,6 +78,7 @@ $background-sidebar: $background-subtle;
 // Imports
 //////////////////////
 
+@import 'custom';
 @import 'base';
 @import 'monokai';
 


### PR DESCRIPTION
This allows for the User to just put their customizations in that file so they don't need to override the `main.scss` file, and miss out on updates.