### PR TITLE
Only give instructions to install as npm/yarn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,10 @@ Using SpectaQL to generate your documentation has a number of benefits, such as:
 1. Install SpectaQL:
 
    ```sh
-   npm install -g spectaql
+   npm install spectaql
    # OR
-   yarn global add spectaql
+   yarn add spectaql
    ```
-
-   This is a global installation, but you can also either:
-
-   - Clone this repository
-   - Add `spectaql` as a dependency to an existing project.
 
 2. Define a `config.yml` that specifies how you'd like to generate your docs.
    See [YAML Options](#yaml-options) for more.


### PR DESCRIPTION
I don't know when it would make sense to have this as a global dependency. I feel like for the most part as a developer consuming your library (which is the reason I'm here) I would just want instructions to include this in my project. 

Adding as a global dependency doesn't offer much value to me and I feel like might cause confusion when this works for someone locally but doesn't work for another developer. Similarly I feel like cloning promotes an anti pattern that could cause some developers to be tempted to start their own fork of this library and miss out on important updates.