### PR TITLE
Remove year from copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Anvil Foundry Inc.
+Copyright (c) Anvil Foundry Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Similar to what Facebook did for react you should be able to just remove the year from the license to avoid updating constantly (https://github.com/facebook/react/pull/13593)