### PR TITLE
Allow hiding title

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -368,6 +368,9 @@ info:
   # Set to true to not render your intro items
   # Default: false
   x-hideIntroItems: false
+  # Set to true to not render your title
+  # Default: false
+  x-hideIntroTitle: false
 
   # Set to true to not render the deprecated label
   # Default: false

--- a/src/themes/default/views/partials/layout/content/main.hbs
+++ b/src/themes/default/views/partials/layout/content/main.hbs
@@ -1,6 +1,8 @@
 {{! DO THE CONTENT }}
 <article id="content">
-  <h1 class="doc-heading">{{info.title}}</h1>
+  {{#unless info.x-hideIntroTitle}}
+    <h1 class="doc-heading">{{info.title}}</h1>
+  {{/unless}}
   {{! Check if there is effectively nothing to do }}
   {{#unless (or info.x-hideIntroduction (and info.x-hideWelcome (or info.x-hideIntroItems (empty info.x-introItems))))}}
     {{>layout/content/introduction/main}}


### PR DESCRIPTION
Hope you have been well. Thanks again for this module -- it's really solving a problem for me.

This PR adds an option to hide the title, which is useful when using the `--embedded` flag, because the surrounding content may already have the title.

Would be very convenient to have this upstream. Cheers and all the best