### PR TITLE
Fix SpectaQL not working on Windows

### DIFF
--- a/src/spectaql/index.js
+++ b/src/spectaql/index.js
@@ -62,7 +62,7 @@ async function run(opts) {
   if (customDataArrangerSuffixThatExists) {
     try {
       arrangeDataModule = await dynamicImport(
-        path.normalize(`${themeDir}/${customDataArrangerSuffixThatExists}`)
+        url.pathToFileURL(path.normalize(`${themeDir}/${customDataArrangerSuffixThatExists}`))
       )
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
When running SpectaQL on Windows, because `path.normalize` returns the absolute path to the file, the following error happens. . We can solve this by using `url`'s handy `pathToFileURL` function which does exactly what we need. 

```D:\p4\ci\main\datahub\node_modules\spectaql\dist\themes\default\data\index.js
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at new NodeError (node:internal/errors:393:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1026:11)
    at defaultResolve (node:internal/modules/esm/resolve:1106:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/cjs/loader:1098:29)
    at importModuleDynamicallyWrapper (node:internal/vm/module:438:21)
    at importModuleDynamically (node:vm:389:46)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at dynamicImport (D:\p4\ci\main\datahub\node_modules\spectaql\dist\spectaql\utils.js:33:18)
    at run (D:\p4\ci\main\datahub\node_modules\spectaql\dist\spectaql\index.js:64:58)
    at loadData (D:\p4\ci\main\datahub\node_modules\spectaql\dist\index.js:546:10)
    at run (D:\p4\ci\main\datahub\node_modules\spectaql\dist\index.js:321:65)
    at file:///D:/p4/ci/main/datahub/spectacle.mjs:7:24
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at Function.all (<anonymous>:null:null)
    at ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at loadESM (node:internal/process/esm_loader:91:5)
    at handleMainPromise (node:internal/modules/run_main:65:12)
 {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}```