### PR TITLE
support deprecation on InputType fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.0
+  - Add support for `inputValueDeprecation`
+  - Dependency updates
+
 ### 2.0.9
   - Add `info.contact.url` to the templates
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -163,6 +163,13 @@ introspection:
   # Default: 1
   fieldExpansionDepth: 1
 
+  # Include support for @deprecated field on InputType fields.
+  # NOTE: Be careful, it appears that if you mark an InputType field as deprecated but do NOT set
+  # this option to `true`, the field will be removed from the schema completely.
+  #
+  # Default: false
+  inputValueDeprecation: false
+
   #
   #
   ##############################################

--- a/examples/data/schema.gql
+++ b/examples/data/schema.gql
@@ -179,7 +179,7 @@ type Subscription {
 "An Input Type for filtering things. `Markdown` and reference interpolation like [`[String!]!`]({{Types.String}}) are supported"
 input FilterInput {
   "Comment for someField. `Markdown` and reference interpolation like [`[String!]!`]({{Types.String}}) are supported"
-  someField: Boolean = false
+  someField: Boolean = false @deprecated(reason: "`someField` is going away")
   "Comment for anotherField"
   anotherField: String
   "Comment for episodeEnums"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectaql",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "A powerful library for autogenerating static GraphQL API documentation",
   "author": "Anvil Foundry Inc. <hello@useanvil.com>",
   "homepage": "https://github.com/anvilco/spectaql",

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,9 @@ const introspectionOptionDefaults = Object.freeze({
 
   removeTrailingPeriodFromDescriptions: false,
 
+  // TODO: make this true by default in next major breaking version?
+  inputValueDeprecation: false,
+
   fieldExpansionDepth: 1,
 
   metadatasReadPath: 'documentation',

--- a/src/spectaql/build-schemas.js
+++ b/src/spectaql/build-schemas.js
@@ -34,11 +34,19 @@ export function buildSchemas(opts) {
       metadataFile,
       headers,
       removeTrailingPeriodFromDescriptions,
+      // TODO: make this true by default in next major breaking version?
+      inputValueDeprecation = false,
     },
   } = spec
 
   let done = false
   let introspectionResponse
+
+  // TODO: make this true by default in next major breaking version?
+  const getIntrospectionQueryOptions = {
+    inputValueDeprecation,
+  }
+
   if (schemaFile) {
     const { schema, directables, directiveName, optionsTypeName } =
       loadSchemaFromSDLFile({
@@ -46,7 +54,10 @@ export function buildSchemas(opts) {
         spectaqlDirectiveOptions,
       })
 
-    introspectionResponse = introspectionResponseFromSchema({ schema })
+    introspectionResponse = introspectionResponseFromSchema({
+      schema,
+      getIntrospectionQueryOptions,
+    })
     if (spectaqlDirectiveOptions.enable && !introspectionResponse.errors) {
       introspectionResponse = addMetadataFromDirectables({
         ...introspectionOptions,
@@ -85,6 +96,7 @@ export function buildSchemas(opts) {
     introspectionResponse = loadIntrospectionResponseFromUrl({
       headers: resolvedHeaders,
       url: introspectionUrl,
+      getIntrospectionQueryOptions,
     })
     done = 'loaded via Introspection URL'
   }

--- a/src/spectaql/graphql-loaders.js
+++ b/src/spectaql/graphql-loaders.js
@@ -31,15 +31,25 @@ function standardizeIntrospectionQueryResult(result) {
   return result.data ? result.data : result
 }
 
-export const introspectionResponseFromSchemaSDL = ({ schemaSDL }) => {
+export const introspectionResponseFromSchemaSDL = ({
+  schemaSDL,
+  getIntrospectionQueryOptions,
+}) => {
   return introspectionResponseFromSchema({
     schema: buildSchema(schemaSDL),
+    getIntrospectionQueryOptions,
   })
 }
 
-export const introspectionResponseFromSchema = ({ schema }) => {
+export const introspectionResponseFromSchema = ({
+  schema,
+  getIntrospectionQueryOptions,
+}) => {
   return standardizeIntrospectionQueryResult(
-    graphqlSync({ schema, source: getIntrospectionQuery() })
+    graphqlSync({
+      schema,
+      source: getIntrospectionQuery(getIntrospectionQueryOptions),
+    })
   )
 }
 
@@ -125,10 +135,14 @@ export const loadIntrospectionResponseFromFile = ({ pathToFile } = {}) => {
   return standardizeIntrospectionQueryResult(fileToObject(pathToFile))
 }
 
-export const loadIntrospectionResponseFromUrl = ({ headers, url }) => {
+export const loadIntrospectionResponseFromUrl = ({
+  headers,
+  url,
+  getIntrospectionQueryOptions,
+}) => {
   const requestBody = {
     operationName: 'IntrospectionQuery',
-    query: getIntrospectionQuery(),
+    query: getIntrospectionQuery(getIntrospectionQueryOptions),
   }
 
   const requestOpts = {

--- a/src/themes/default/views/partials/graphql/kinds/input-object.hbs
+++ b/src/themes/default/views/partials/graphql/kinds/input-object.hbs
@@ -19,13 +19,16 @@
           {{#each inputFields}}
             <tr>
               <td>
-                {{! The Value column }}
+                {{! The Input Field column }}
                 {{~> graphql/name-and-type }}
               </td>
               <td>
                 {{! The Description column }}
                 {{#if description}}
                   {{>graphql/_description-with-defaults}}
+                {{/if}}
+                {{#if (and deprecationReason (not @root.info.x-hideDeprecationReason))}}
+                  <span class="deprecation-reason">{{ md deprecationReason stripParagraph=true }}</span>
                 {{/if}}
               </td>
             </tr>

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -27,6 +27,8 @@ describe('index', function () {
       expect(options.specData.introspection).to.include({
         removeTrailingPeriodFromDescriptions: false,
 
+        inputValueDeprecation: false,
+
         metadatasReadPath: 'documentation',
         metadatasWritePath: 'documentation',
 

--- a/vendor-src/resource-embedder/package.json
+++ b/vendor-src/resource-embedder/package.json
@@ -49,7 +49,7 @@
     "coffeescript": "^2.6.1",
     "graceful-fs": "~4.2.10",
     "grunt": "~1.5.3",
-    "htmlparser2": "~8.0.1",
+    "htmlparser2": "~9.0.0",
     "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Support for `@deprecated` on fields on `InputType`s.

Fixes https://github.com/anvilco/spectaql/issues/827