### PR TITLE
FIX incorrect hashtag selection in default theme

### DIFF
--- a/src/themes/default/javascripts/scroll-spy.js
+++ b/src/themes/default/javascripts/scroll-spy.js
@@ -73,7 +73,7 @@ function scrollSpy() {
 
     var activeEl = document.querySelector(`.${ACTIVE_CLASS}`)
     var nextEl = section
-      ? document.querySelector('#nav a[href*=' + section.id + ']')
+      ? document.querySelector('#nav a[href="#' + section.id + '"]')
       : null
 
     var parentNextEl = getParentSection(nextEl)


### PR DESCRIPTION
Hi,

There is an issue with the scroll-spy from the default theme.
When you have multiple nav items that share a common root, the scroll spy will always select the first one due to the `'#nav a[href*=' + section.id + ']'` fuzzy selector for the `nextEl`.

Example in my case:
1 nav item has `href="#definition-ActivityAlertClassification"`  
1 nav item, lower in the tree, has `href="#definition-ActivityAlert"`

When scrolling past `definition-ActivityAlert`, the current scroll spy will incorrectly select `definition-ActivityAlertClassification` in the nav as it's the first match.

**Solution**
Switching to an exact value match `'#nav a[href="#' + section.id + '"]'` fixed the issue.  

If there was a specific reason for the previous query selector, happy to change the solution to support that use case.