### PR TITLE
fix: remove random scalar examples

### DIFF
--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -43,22 +43,16 @@ const QUOTE_TAG_REGEX = new RegExp(QUOTE_TAG, 'g')
 const QUOTE_HTML = '&quot;'
 const QUOTE_HTML_REGEX = new RegExp(QUOTE_HTML, 'g')
 
-// Map Scalar types to example data to use fro them
+// Map Scalar types to example data to use for them
 const SCALAR_TO_EXAMPLE = {
-  String: ['abc123', 'xyz789'],
-  Int: [123, 987],
-  Float: [123.45, 987.65],
+  String: 'abc123',
+  Int: 123,
+  Float: 123.45,
   Boolean: [true, false],
-  Date: [
-    new Date(),
-    new Date(new Date().setMonth(new Date().getMonth() - 6).valueOf()),
-  ].map((date) => date.toISOString()),
-  DateTime: [
-    new Date(),
-    new Date(new Date().setMonth(new Date().getMonth() - 6).valueOf()),
-  ].map((date) => date.toISOString()),
+  Date: (new Date(0)).toISOString(),
+  DateTime: (new Date(0)).toISOString(),
   JSON: SPECIAL_TAG + '{}' + SPECIAL_TAG,
-  ID: [4, '4'],
+  ID: '4',
 }
 
 function unwindTags(str) {


### PR DESCRIPTION
Heya! While working with spectaql, I noticed that example outputs produce random results - this can be an issue, since it means that multiple runs of spectaql with the same input can very easily produce different output.

Ideally, this shouldn't be the case, and all output should be as consistent and reproducible as possible.

Maybe this isn't the right way to go about this! :tada: And there's a neater way to do it, maybe a setting that allows for getting reproducible output by inspecting the environment/etc - happy to update the PR to do something else, if this approach isn't desirable.