### PR TITLE
Prevent stray html/head/body elements

### DIFF
--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -473,5 +473,5 @@ export function printSchema(value, _root) {
   // There is an issue with `marked` not formatting a leading quote in a single,
   // quoted string value. By unwinding the special tags after converting to markdown
   // we can avoid that issue.
-  return cheerioLoad(unwindTags(quoted)).html()
+  return cheerioLoad(unwindTags(quoted), null, false).html()
 }


### PR DESCRIPTION
As documented [1], cheerio will wrap output in
`<html><head></head><body>...</body></html>`. These fragments show up in various places in generated files. Call `load()` with the documented arguments to avoid this.

[1] https://cheerio.js.org/docs/basics/loading