### PR TITLE
Security: Unsafe HTML construction in helper allows injection into output

### DIFF
--- a/src/themes/default/helpers/spanWrap.js
+++ b/src/themes/default/helpers/spanWrap.js
@@ -2,6 +2,11 @@
 //
 // Options:
 //   clazz (String)
+const escapeHtml = (input) => String(input).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]))
+
 module.exports = function (value, options) {
-  return `<span class="${options?.hash?.className || ''}">${value}</span>`
+  const className = options?.hash?.className
+  const safeClassName = typeof className === 'string' && /^[a-zA-Z0-9_- ]+$/.test(className) ? className : ''
+
+  return `<span class="${escapeHtml(safeClassName)}">${escapeHtml(value)}</span>`
 }


### PR DESCRIPTION
## Problem

`spanWrap` interpolates `className` and `value` directly into an HTML string. If either comes from untrusted spec data, this enables HTML attribute/content injection (e.g., breaking out of attributes or injecting tags) when rendered unescaped or via triple-stash usage.

**Severity**: `high`
**File**: `src/themes/default/helpers/spanWrap.js`

## Solution

Escape both attribute and text contexts before interpolation (or build DOM-safe output via templating primitives). Restrict `className` to a safe pattern like `/^[a-zA-Z0-9_- ]+$/`.

## Changes

- `src/themes/default/helpers/spanWrap.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
