### PR TITLE
feat: display all production servers when multiple are marked

### DIFF
--- a/src/themes/default/helpers/generateApiEndpoints.js
+++ b/src/themes/default/helpers/generateApiEndpoints.js
@@ -5,15 +5,28 @@ module.exports = function (options) {
     options?.data?.root?.allOptions?.specData?.spectaql?.displayAllServers ===
     true
   if (!displayAllServers) {
+    const productionServers = servers?.filter(
+      (server) => server.url && server.production
+    )
+    if (productionServers?.length > 1) {
+      return productionServers
+        .map(
+          (server) =>
+            '# ' +
+            (server.description?.trim() || 'Endpoint') +
+            ':\n' +
+            server.url.trim() +
+            '\n'
+        )
+        .join('')
+    }
     if (url) {
       return url
     }
     if (server?.url) {
       return server.url
     }
-    const fallbackServer =
-      servers?.find((server) => server.url && server.production) ||
-      servers?.find((server) => server.url)
+    const fallbackServer = productionServers?.[0] || servers?.find((server) => server.url)
     if (fallbackServer) {
       return fallbackServer.url
     }

--- a/test/src/helpers/generateApiEndpoints.test.js
+++ b/test/src/helpers/generateApiEndpoints.test.js
@@ -37,6 +37,27 @@ describe('generateApiEndpoints', function () {
     },
   ])
 
+  def('multiProductionServers', () => [
+    {
+      url: 'devGraphql',
+      description: 'Dev GraphQL',
+    },
+    {
+      url: 'devWs',
+      description: 'Dev WebSocket',
+    },
+    {
+      url: 'prodGraphql',
+      description: 'Production GraphQL',
+      production: true,
+    },
+    {
+      url: 'prodWs',
+      description: 'Production WebSocket',
+      production: true,
+    },
+  ])
+
   context('displayAllServers is false', function () {
     it('uses url', function () {
       expect(generateApiEndpoints($.options)).to.eql('foorl')
@@ -63,6 +84,18 @@ describe('generateApiEndpoints', function () {
             expect(generateApiEndpoints($.options)).to.eql('server1url')
           })
         })
+      })
+    })
+
+    context('multiple production servers', function () {
+      def('url', () => undefined)
+      def('server', () => undefined)
+      def('servers', () => $.multiProductionServers)
+
+      it('displays all production servers', function () {
+        expect(generateApiEndpoints($.options)).to.eql(
+          '# Production GraphQL:\nprodGraphql\n# Production WebSocket:\nprodWs\n'
+        )
       })
     })
   })


### PR DESCRIPTION
When displayAllServers is false and multiple servers have production: true, all production servers are now shown with their descriptions instead of only the first one. This allows documenting separate endpoints (e.g. GraphQL and WebSocket) for the same environment. Single production server behavior is unchanged.

fixes #1088 